### PR TITLE
Replaced apistar with local openapi theme files

### DIFF
--- a/examples/openapi_documentation.py
+++ b/examples/openapi_documentation.py
@@ -1,0 +1,31 @@
+from marshmallow import Schema, fields
+
+import dune
+
+api = dune.API()
+
+
+@api.schema("Pet")
+class PetSchema(Schema):
+    name = fields.Str()
+
+
+@api.route("/")
+def route(req, resp):
+    """A cute furry animal endpoint.
+    ---
+    get:
+        description: Get a random pet
+        responses:
+            200:
+                description: A pet to be returned
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/Pet'
+    """
+    resp.media = PetSchema().dump({"name": "little orange"})
+
+
+if __name__ == "__main__":
+    api.run()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,8 @@ dependencies = [
     "requests-toolbelt>=1.0.0",
     "graphene>=3.3",
     "itsdangerous>=2.1.2",
-    "apistar>=0.7.2",
     "graphql-server>=3.0.0b7",
+    "marshmallow>=3.21.1",
 ]
 readme = "README.md"
 requires-python = ">= 3.8"

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -20,8 +20,6 @@ anyio==4.3.0
     # via watchfiles
 apispec==6.6.0
     # via dune
-apistar==0.7.2
-    # via dune
 babel==2.14.0
     # via sphinx
 certifi==2024.2.2
@@ -35,7 +33,6 @@ chardet==5.2.0
 charset-normalizer==3.3.2
     # via requests
 click==8.1.7
-    # via apistar
     # via uvicorn
 coverage==7.4.4
     # via pytest-cov
@@ -78,15 +75,17 @@ iniconfig==2.0.0
 itsdangerous==2.1.2
     # via dune
 jinja2==3.1.3
-    # via apistar
     # via dune
     # via sphinx
 markupsafe==2.1.5
     # via jinja2
+marshmallow==3.21.1
+    # via dune
 nodeenv==1.8.0
     # via pre-commit
 packaging==24.0
     # via apispec
+    # via marshmallow
     # via pytest
     # via sphinx
 platformdirs==4.2.0
@@ -106,12 +105,10 @@ python-dotenv==1.0.1
 python-multipart==0.0.9
     # via dune
 pyyaml==6.0.1
-    # via apistar
     # via dune
     # via pre-commit
     # via uvicorn
 requests==2.31.0
-    # via apistar
     # via dune
     # via requests-toolbelt
     # via sphinx
@@ -141,8 +138,6 @@ sphinxcontrib-serializinghtml==1.1.10
     # via sphinx
 starlette==0.37.2
     # via dune
-typesystem==0.4.1
-    # via apistar
 typing-extensions==4.10.0
     # via graphql-server
 urllib3==2.2.1

--- a/requirements.lock
+++ b/requirements.lock
@@ -17,8 +17,6 @@ anyio==4.3.0
     # via watchfiles
 apispec==6.6.0
     # via dune
-apistar==0.7.2
-    # via dune
 certifi==2024.2.2
     # via requests
 chardet==5.2.0
@@ -26,7 +24,6 @@ chardet==5.2.0
 charset-normalizer==3.3.2
     # via requests
 click==8.1.7
-    # via apistar
     # via uvicorn
 docopt==0.6.2
     # via dune
@@ -50,22 +47,22 @@ idna==3.6
 itsdangerous==2.1.2
     # via dune
 jinja2==3.1.3
-    # via apistar
     # via dune
 markupsafe==2.1.5
     # via jinja2
+marshmallow==3.21.1
+    # via dune
 packaging==24.0
     # via apispec
+    # via marshmallow
 python-dotenv==1.0.1
     # via uvicorn
 python-multipart==0.0.9
     # via dune
 pyyaml==6.0.1
-    # via apistar
     # via dune
     # via uvicorn
 requests==2.31.0
-    # via apistar
     # via dune
     # via requests-toolbelt
 requests-toolbelt==1.0.0
@@ -76,8 +73,6 @@ sniffio==1.3.1
     # via anyio
 starlette==0.37.2
     # via dune
-typesystem==0.4.1
-    # via apistar
 typing-extensions==4.10.0
     # via graphql-server
 urllib3==2.2.1

--- a/src/dune/ext/schema/docs/elements.html
+++ b/src/dune/ext/schema/docs/elements.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, shrink-to-fit=no"
+    />
+    <title>{{ title }} {{ version }}</title>
+    <!-- Embed elements Elements via Web Component -->
+    <script src="https://unpkg.com/@stoplight/elements/web-components.min.js"></script>
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/@stoplight/elements/styles.min.css"
+    />
+  </head>
+  <body>
+    <elements-api
+      apiDescriptionUrl="{{ schema_url }}"
+      router="hash"
+      layout="sidebar"
+    />
+  </body>
+</html>

--- a/src/dune/ext/schema/docs/rapidoc.html
+++ b/src/dune/ext/schema/docs/rapidoc.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<!-- Important: must specify -->
+<html>
+  <head>
+    <title>{{ title }} {{ version }}</title>
+    <meta charset="utf-8" />
+    <!-- Important: rapi-doc uses utf8 characters -->
+    <script
+      type="module"
+      src="https://unpkg.com/rapidoc/dist/rapidoc-min.js"
+    ></script>
+  </head>
+  <body>
+    <rapi-doc spec-url="{{ schema_url }}" show-header="false"> </rapi-doc>
+  </body>
+</html>

--- a/src/dune/ext/schema/docs/redoc.html
+++ b/src/dune/ext/schema/docs/redoc.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>{{ title }} {{ version }}</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link
+      href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700"
+      rel="stylesheet"
+    />
+
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <redoc spec-url="{{ schema_url }}"></redoc>
+    <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"></script>
+  </body>
+</html>

--- a/src/dune/ext/schema/docs/swaggerui.html
+++ b/src/dune/ext/schema/docs/swaggerui.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>{{ title }} {{ version }}</title>
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="https://unpkg.com/swagger-ui-dist/swagger-ui.css"
+    />
+    <style>
+      html {
+        box-sizing: border-box;
+        overflow: -moz-scrollbars-vertical;
+        overflow-y: scroll;
+      }
+
+      *,
+      *:before,
+      *:after {
+        box-sizing: inherit;
+      }
+
+      body {
+        margin: 0;
+        background: #fafafa;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div id="swagger-ui"></div>
+
+    <script src="https://unpkg.com/swagger-ui-dist/swagger-ui-bundle.js"></script>
+    <script src="https://unpkg.com/swagger-ui-dist/swagger-ui-standalone-preset.js"></script>
+    <script>
+      window.onload = function () {
+        const ui = SwaggerUIBundle({
+          url: "{{ schema_url }}",
+          dom_id: "#swagger-ui",
+          deepLinking: true,
+          presets: [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset],
+          plugins: [SwaggerUIBundle.plugins.DownloadUrl],
+          layout: "BaseLayout",
+        });
+      };
+    </script>
+  </body>
+</html>

--- a/src/dune/statics.py
+++ b/src/dune/statics.py
@@ -1,5 +1,6 @@
+OPENAPI_THEMES = ["elements", "rapidoc", "redoc", "swaggerui"]
 DEFAULT_ENCODING = "utf-8"
-DEFAULT_API_THEME = "swaggerui"
+DEFAULT_OPENAPI_THEME = "elements"
 DEFAULT_SESSION_COOKIE = "Responder-Session"
 DEFAULT_SECRET_KEY = "NOTASECRET"
 


### PR DESCRIPTION
This PR addresses [issue #1](https://github.com/tabotkevin/dune/issues/1) by replacing the `apistar` library, which currently has a bug preventing `dune` from starting. Since the `apistar` library has been archived, it's crucial to replace it.

The fix involves replacing the library with local OpenAPI documentation files for popular themes. Four themes have been added: `elements`, `rapidoc`, `redoc`, and `swagger_ui`, with `swaggerui` set as the default theme.

Users can select their API documentation theme by setting the `api_theme` variable in the `API` class instantiation to one of the mentioned themes. They can then visit `/docs` to view the rendered documentation. If no theme is specified, the documentation will be rendered using `swaggerui` as the default.

e.g 

``` python
from marshmallow import Schema, fields

import dune

api = dune.API()


@api.schema("Pet")
class PetSchema(Schema):
    name = fields.Str()


@api.route("/")
def route(req, resp):
    """A cute furry animal endpoint.
    ---
    get:
        description: Get a random pet
        responses:
            200:
                description: A pet to be returned
                content:
                    application/json:
                        schema:
                            $ref: '#/components/schemas/Pet'
    """
    resp.media = PetSchema().dump({"name": "little orange"})


if __name__ == "__main__":
    api.run()


```