### PR TITLE
added support for endpoint request methods

### DIFF
--- a/examples/request_methods.py
+++ b/examples/request_methods.py
@@ -1,0 +1,30 @@
+import dune
+
+api = dune.API()
+
+
+@api.route("/greet/{greeting}")
+async def greet(req, resp, *, greeting):  # Default `GET` request.
+    resp.text = f"{greeting}, world!"
+
+
+@api.route("/create", methods=["POST"])
+async def book(req, resp):
+    resp.media = await req.media()
+
+
+@api.route("/book/{id}")
+class BookResource:
+    def on_get(self, req, resp, *, id):
+        resp.text = f"Book - {id}"
+        resp.status_code = api.status_codes.HTTP_201
+
+    async def on_post(self, req, resp, *, id):
+        resp.media = await req.media()
+
+    def on_request(self, req, resp, *, id):  # any request method.
+        resp.headers.update({"X-Life": f"{id}"})
+
+
+if __name__ == "__main__":
+    api.run()

--- a/src/dune/api.py
+++ b/src/dune/api.py
@@ -182,6 +182,7 @@ class API:
         check_existing=True,
         websocket=False,
         before_request=False,
+        methods=("GET",),
     ):
         """Adds a route to the API.
 
@@ -189,6 +190,7 @@ class API:
         :param endpoint: The endpoint for the route -- can be a callable, or a class.
         :param default: If ``True``, all unknown requests will route to this view.
         :param static: If ``True``, and no endpoint was passed, render "static/index.html", and it will become a default route.
+        :param methods: A list of supported request methods for this endpoint. e.g ["GET", "POST"].
         """
 
         # Path
@@ -205,6 +207,7 @@ class API:
             websocket=websocket,
             before_request=before_request,
             check_existing=check_existing,
+            methods=methods,
         )
 
     async def _static_response(self, req, resp):


### PR DESCRIPTION
This PR fixes this [issue](https://github.com/tabotkevin/dune/issues/3). I propose an enhancement to annotate endpoints with their accepted request types, such as "POST", "GET", "PUT", and others. The intention is to ensure appropriate handling of errors when the incoming request method does not match the expected method for an endpoint. If an endpoint lacks annotations, it defaults to accepting any request method. It's important to note that the current version of Responder only supports this functionality within class-based views.

For instance, leveraging the annotation approach:

`@api.route("/", methods=["POST"])`

This enhancement streamlines the handling of request methods, promoting more explicit endpoint definition and ensuring accurate request handling within the Responder framework.

See other examples in the `examples/enpoint_request_methods.py` file.