### PR TITLE
Request validation for media, headers, query, and cookies

### DIFF
--- a/examples/request_validation.py
+++ b/examples/request_validation.py
@@ -1,0 +1,123 @@
+import time
+
+from marshmallow import Schema, fields
+from pydantic import BaseModel
+
+import dune
+
+api = dune.API()
+
+
+class BookSchema(BaseModel):  # Pydantic schema
+    price: float
+    title: str
+
+
+class HeaderSchema(Schema):  # Mashmellow schema
+    x_version = fields.String(data_key="X-Version", required=True)
+
+
+class CookiesSchema(BaseModel):
+    max_age: int
+    is_cheap: bool
+
+
+class QuerySchema(Schema):
+    page = fields.Int(missing=1)
+    limit = fields.Int(missing=10)
+
+
+class ItemModel(BaseModel):
+    hello: str
+
+
+# Manual validation
+@api.route("/shop", methods=["POST"])
+async def shop(req, resp):
+    data = await req.validate(BookSchema)
+    resp.media = data
+
+
+# Media routes
+@api.route("/book", methods=["POST"])
+@api.input(BookSchema)  # default location is `media` default media key is `data`
+async def book_create(req, resp, *, data):
+    @api.background.task
+    def process_book(book):
+        time.sleep(2)
+        print(book)
+
+    process_book(data)
+    resp.media = {"msg": "created"}
+
+
+# Query(params) route
+@api.route("/books")
+@api.input(QuerySchema, location="query")
+async def get_books(req, resp, *, query):
+    print(query)  # e.g {'page': 2, 'limit': 20}
+    resp.media = {"books": [{"title": "Python", "price": 39.00}]}
+
+
+# Headers routes
+@api.route("/book/{id}", methods=["POST"])
+@api.input(HeaderSchema, location="headers")
+async def book(req, resp, *, id, headers):
+    """Header Pydantic"""
+    print(headers)  # e.g {"x_version": "2.4.5"}
+    resp.media = {"title": f"Lost {id}", "price": 9.99}
+
+
+# Cookies routes
+@api.route("/")
+@api.input(CookiesSchema, location="cookies")
+async def home(req, resp, *, cookies):
+    """Cookies Mashmellow"""
+    print(cookies)  # e.g {"max_age": "123", "is_cheap": True}
+    resp.text = "Welcome to book store."
+
+
+# Demonstrating stacking of decorators routes
+@api.route("/store", methods=["POST"])
+@api.input(
+    CookiesSchema, location="cookies", key="c"
+)  # default key is the value of location.
+@api.input(BookSchema)
+async def store(req, resp, *, c, data):
+    print(f"Cookies: {c}")
+    resp.media = data
+
+
+# Let's make an HTTP request to the server, to test it out.'}
+
+# Media requests
+r = api.requests.post("http://;/book", json={"price": 9.99, "title": "Pydantic book"})
+print(r.json())
+
+
+# Query(params) requests
+r = api.requests.get("http://;/books?page=2&limit=20")
+print(r.json())
+
+
+# Headers requests
+r = api.requests.post("http://;/book/1", headers={"X-Version": "2.4.5"})
+print(r.json())
+
+
+# Cookies requests
+r = api.requests.get("http://;/", cookies={"max_age": "123", "is_cheap": "True"})
+print(r.text)
+
+
+r = api.requests.post(
+    "http://;/store",
+    json={"price": 9.99, "title": "Pydantic book"},
+    cookies={"max_age": "123", "is_cheap": "True"},
+)
+print(r.json())
+
+
+# Manual validation
+r = api.requests.post("http://;/shop", json={"price": 9.99, "title": "Harry Potter"})
+print(r.text)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,28 +2,27 @@
 name = "dune"
 version = "0.1.0"
 description = "Add your description here"
-authors = [
-    { name = "Tabot Kevin", email = "tabot.kevin@gmail.com" }
-]
+authors = [{ name = "Tabot Kevin", email = "tabot.kevin@gmail.com" }]
 dependencies = [
-    "starlette>=0.37.2",
-    "uvicorn[standard]>=0.29.0",
-    "aiofiles>=23.2.1",
-    "pyyaml>=6.0.1",
-    "requests>=2.31.0",
-    "jinja2>=3.1.3",
-    "rfc3986>=2.0.0",
-    "python-multipart>=0.0.9",
-    "chardet>=5.2.0",
-    "apispec>=1.0.0b1",
-    "whitenoise>=6.6.0",
-    "docopt>=0.6.2",
-    "requests-toolbelt>=1.0.0",
-    "graphene>=3.3",
-    "itsdangerous>=2.1.2",
-    "graphql-server>=3.0.0b7",
-    "marshmallow>=3.21.1",
-    "flask>=3.0.3",
+  "starlette>=0.37.2",
+  "uvicorn[standard]>=0.29.0",
+  "aiofiles>=23.2.1",
+  "pyyaml>=6.0.1",
+  "requests>=2.31.0",
+  "jinja2>=3.1.3",
+  "rfc3986>=2.0.0",
+  "python-multipart>=0.0.9",
+  "chardet>=5.2.0",
+  "apispec>=1.0.0b1",
+  "whitenoise>=6.6.0",
+  "docopt>=0.6.2",
+  "requests-toolbelt>=1.0.0",
+  "graphene>=3.3",
+  "itsdangerous>=2.1.2",
+  "graphql-server>=3.0.0b7",
+  "marshmallow>=3.21.1",
+  "flask>=3.0.3",
+  "pydantic>=2.7.0",
 ]
 readme = "README.md"
 requires-python = ">= 3.8"
@@ -35,12 +34,12 @@ build-backend = "hatchling.build"
 [tool.rye]
 managed = true
 dev-dependencies = [
-    "pytest>=8.1.1",
-    "pytest-mock>=3.14.0",
-    "sphinx>=7.2.6",
-    "pytest-cov>=5.0.0",
-    "pre-commit>=3.7.0",
-    "httpx>=0.27.0",
+  "pytest>=8.1.1",
+  "pytest-mock>=3.14.0",
+  "sphinx>=7.2.6",
+  "pytest-cov>=5.0.0",
+  "pre-commit>=3.7.0",
+  "httpx>=0.27.0",
 ]
 
 [tool.hatch.metadata]

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -14,6 +14,8 @@ alabaster==0.7.16
     # via sphinx
 aniso8601==9.0.1
     # via graphene
+annotated-types==0.6.0
+    # via pydantic
 anyio==4.3.0
     # via httpx
     # via starlette
@@ -101,6 +103,10 @@ platformdirs==4.2.0
 pluggy==1.4.0
     # via pytest
 pre-commit==3.7.0
+pydantic==2.7.0
+    # via dune
+pydantic-core==2.18.1
+    # via pydantic
 pygments==2.17.2
     # via sphinx
 pytest==8.1.1
@@ -148,6 +154,8 @@ starlette==0.37.2
     # via dune
 typing-extensions==4.10.0
     # via graphql-server
+    # via pydantic
+    # via pydantic-core
 urllib3==2.2.1
     # via requests
 uvicorn==0.29.0

--- a/requirements.lock
+++ b/requirements.lock
@@ -12,6 +12,8 @@ aiofiles==23.2.1
     # via dune
 aniso8601==9.0.1
     # via graphene
+annotated-types==0.6.0
+    # via pydantic
 anyio==4.3.0
     # via starlette
     # via watchfiles
@@ -63,6 +65,10 @@ marshmallow==3.21.1
 packaging==24.0
     # via apispec
     # via marshmallow
+pydantic==2.7.0
+    # via dune
+pydantic-core==2.18.1
+    # via pydantic
 python-dotenv==1.0.1
     # via uvicorn
 python-multipart==0.0.9
@@ -83,6 +89,8 @@ starlette==0.37.2
     # via dune
 typing-extensions==4.10.0
     # via graphql-server
+    # via pydantic
+    # via pydantic-core
 urllib3==2.2.1
     # via requests
 uvicorn==0.29.0

--- a/tests/test_encodings.py
+++ b/tests/test_encodings.py
@@ -6,7 +6,7 @@ def test_custom_encoding(api, session):
         req.encoding = "ascii"
         resp.text = await req.text
 
-    r = session.post(api.url_for(route), data=data)
+    r = session.post(api.url_for(route), content=data)
     assert r.text == data
 
 
@@ -17,5 +17,5 @@ def test_bytes_encoding(api, session):
     async def route(req, resp):
         resp.text = (await req.content).decode("utf-8")
 
-    r = session.post(api.url_for(route), data=data)
+    r = session.post(api.url_for(route), content=data)
     assert r.content == data


### PR DESCRIPTION
check `examples/request_validation.py`

"""
Decorator for parsing and validating input schema.
   Supports both Pydantic and Marshmallow.

Usage::
"""

``` python

  import time

  from pydantic import BaseModel
  from marshmallow import Schema, fields
  import dune

  class Item(BaseModel)
      name: str

 
  class HeaderSchema(Schema):
      x_version = fields.String(data_key="X-Version", required=True)

  api = dune.API()

  @api.route("/", methods=["POST"])
  @api.input(HeaderSchema, location="headers")
  async def home(req, resp, *, headers):
      print(headers)
      resp.text = "headers verified"
 
   r = api.requests.post("http://;/", headers={"X-Version": "2.5.6"})


  @api.route("/create", methods=["POST"])
  @api.input(Item)
  def create_item(req, resp, *, data):
      @api.background.task
      def process_item(item):
          time.sleep(2)
          print(item)   # e.g {"name": "Monster Hunter"}

      process_item(data)
      resp.media = {"msg": "created"}
      
       r = api.requests.post("http://;/book_headers", data= {"name": "Monster Hunter"})
```