### PR TITLE
Added support for both Pydantic and Marshmallow schemas in openapi spec

### DIFF
--- a/examples/request_validation.py
+++ b/examples/request_validation.py
@@ -8,11 +8,13 @@ import dune
 api = dune.API()
 
 
+@api.schema("BookSchema")
 class BookSchema(BaseModel):  # Pydantic schema
     price: float
     title: str
 
 
+@api.schema("HeaderSchema")
 class HeaderSchema(Schema):  # Mashmellow schema
     x_version = fields.String(data_key="X-Version", required=True)
 

--- a/src/dune/ext/schema/__init__.py
+++ b/src/dune/ext/schema/__init__.py
@@ -84,7 +84,10 @@ class Schema:
                 spec.path(path=route.route, operations=operations)
 
         for name, schema in self.schemas.items():
-            spec.components.schema(name, schema=schema)
+            if hasattr(schema, "schema"):
+                spec.components.schema(name, schema.schema())  # pydantic.
+            else:
+                spec.components.schema(name, schema=schema)  # marshmallow.
 
         return spec
 


### PR DESCRIPTION
Following the below example and visiting the docs [endpoint](http://127.0.0.1:5042/docs) you should see both the BookSchema(Pydantic) and the HeaderSchema(Marshmallow) at the same time.

``` python
from marshmallow import Schema, fields
from pydantic import BaseModel

import dune

api = dune.API()


@api.schema("BookSchema")
class BookSchema(BaseModel):  # Pydantic schema
    price: float
    title: str


@api.schema("HeaderSchema")
class HeaderSchema(Schema):  # Mashmellow schema
    x_version = fields.String(data_key="X-Version", required=True)


@api.route("/{greeting}")
async def greet_world(req, resp, *, greeting):
    resp.text = f"{greeting}, world!"


if __name__ == "__main__":
    api.run()

```