### PR TITLE
Added decorator to capture other responses of an endpoint.

### DIFF
--- a/examples/hello_expect.py
+++ b/examples/hello_expect.py
@@ -1,0 +1,35 @@
+import time
+
+from pydantic import BaseModel
+
+import dune
+
+api = dune.API()
+
+
+class BookSchema(BaseModel):
+    price: float
+    title: str
+
+
+@api.route("/book", methods=["POST"])
+@api.input(BookSchema)
+@api.expect(
+    {
+        401: "Invalid access or refresh token",
+        403: "Please verify your account",
+    }
+)
+async def book_create(req, resp, *, data):
+    @api.background.task
+    def process_book(book):
+        time.sleep(2)
+        print(book)
+
+    process_book(data)
+    resp.media = {"msg": "created"}
+
+
+r = api.requests.post("http://;/book", json={"price": 9.99, "title": "Rust book"})
+print(r.json())
+print(f"Route's _spec: {book_create._spec}")

--- a/src/dune/api.py
+++ b/src/dune/api.py
@@ -329,6 +329,44 @@ class API:
         """
         return self.templates.render_string(source, *args, **kwargs)
 
+    def _annotate(self, f, **kwargs):
+        """Utilized to store essential route details for later inclusion in the
+        OpenAPI documentation of the route."""
+
+        if not hasattr(f, "_spec"):
+            f._spec = {}
+        for key, value in kwargs.items():
+            f._spec[key] = value
+
+    def expect(self, responses):
+        """A decorator that receives key pair values of status_codes and descriptions
+        for other responses expected the by an endpoint. This decorator is only
+        used for OpenAPI documentation.
+
+        :params codes: e.g {401: 'Invalid access or refresh token', 404: 'Item not found'}
+
+
+        Usage::
+            api = dune.API()
+
+            @api.route("/create")
+            @api.input(ItemCreate)
+            @api.expect(
+                {
+                    401: "Invalid access or refresh token",
+                    403: "Please verify your account",
+                }
+            )
+            async def create_items(req, resp):
+                resp.text = "Item created"
+        """
+
+        def decorator(f):
+            self._annotate(f, responses=responses)
+            return f
+
+        return decorator
+
     def _parse_request(self, schema, location, key=None, unknown=None):
         """A decorator for parsing and validating input schema from a specified request location.
         Supports both Pydantic and Marshmallow.


### PR DESCRIPTION
check `examples/hello_expect.py`

"""
Decorator to capture other responses of an endpoint.


Usage::
"""
``` python

import time
from pydantic import BaseModel
import dune

api = dune.API()


class BookSchema(BaseModel): 
    price: float
    title: str


@api.route("/book", methods=["POST"])
@api.input(BookSchema)
@api.expect(
    {
        401: "Invalid access or refresh token",
        403: "Please verify your account",
    }
)
async def book_create(req, resp, *, data):
    @api.background.task
    def process_book(book):
        time.sleep(2)
        print(book)

    process_book(data)
    resp.media = {"msg": "created"}


r = api.requests.post("http://;/book", json={"price": 9.99, "title": "Rust book"})
print(r.json())
print(f"Route's _spec: {book_create._spec}")
```